### PR TITLE
Contract address changed to eip-55 checksum format

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Contract which implements utilities for working with datetime values in
 ethereum.
 
-Contract Address: `0x1a6184cd4c5bea62b0116de7962ee7315b7bcbce`
+Contract Address: `0x1a6184CD4C5Bea62B0116de7962EE7315B7bcBce`  
 
 Compiled with:
 


### PR DESCRIPTION
Remix (and other tools) will reject contract addresses not using the upper/lowercase checksum specified here:
https://github.com/ethereum/EIPs/blob/master/EIPS/eip-55.md