### PR TITLE
Sol v0.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,19 @@
 name: "CI"
-on:
-  push:
+on: [push]
 jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - uses: actions/setup-node@v2
-      with:
-        node-version: '14'
-    - name: Install Dependencies
-      run: pip install -r requirements-dev.txt
-    - name: Install Ganache
-      run: npm install -g ganache-cli
-    - name: Run Tests
-      run: brownie test
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.8.10"
+      - uses: actions/setup-node@v2
+        with:
+          node-version: "14"
+      - name: Install Dependencies
+        run: pip install -r requirements-dev.txt
+      - name: Install Ganache
+        run: npm install -g ganache-cli
+      - name: Run Tests
+        run: brownie test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: "CI"
+on:
+  push:
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '14'
+    - name: Install Dependencies
+      run: pip install -r requirements-dev.txt
+    - name: Install Ganache
+      run: npm install -g ganache-cli
+    - name: Run Tests
+      run: brownie test

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ build/
 dist/
 chains/
 **/_build
+__pycache__
+.env
+.history
+.hypothesis/
+reports/

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Contract which implements utilities for working with datetime values in
 ethereum.
 
-Contract Deployments: 
+Contract Deployments:
 
 - Mainnet: [`0x1a6184CD4C5Bea62B0116de7962EE7315B7bcBce`](https://etherscan.io/address/0x1a6184cd4c5bea62b0116de7962ee7315b7bcbce)
 - Rinkeby: [`0x92482Ba45A4D2186DafB486b322C6d0B88410FE7`](https://rinkeby.etherscan.io/address/0x92482ba45a4d2186dafb486b322c6d0b88410fe7)
@@ -84,3 +84,18 @@ Given a unix timestamp, returns the `DateTime.weekday` value for the timestamp.
 * `toTimestamp(uint16 year, uint8 month, uint8 day) constant returns (uint timestamp)`
 
 Returns the unix timestamp representation for the given date and time values.
+
+### Running Tests
+
+First, install dependencies
+
+```bash
+pip install -r requirements-dev.txt
+npm install -g ganache-cli
+```
+
+Then, run tests with
+
+```bash
+brownie test
+```

--- a/contracts/DateTime.sol
+++ b/contracts/DateTime.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.4.16;
+pragma solidity ^0.8.0;
 
 contract DateTime {
         /*
@@ -57,7 +57,7 @@ contract DateTime {
                 }
         }
 
-        function parseTimestamp(uint timestamp) internal pure returns (_DateTime dt) {
+        function parseTimestamp(uint timestamp) internal pure returns (_DateTime memory dt) {
                 uint secondsAccountedFor = 0;
                 uint buf;
                 uint8 i;

--- a/interfaces/api.sol
+++ b/interfaces/api.sol
@@ -1,6 +1,8 @@
-contract DateTimeAPI {
+pragma solidity ^0.4.16;
+
+interface DateTimeAPI {
         /*
-         *  Abstract contract for interfacing with the DateTime contract.
+         *  Interface for interfacing with the DateTime contract.
          *
          */
         function isLeapYear(uint16 year) constant returns (bool);

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,2 @@
 pytz==2015.6
-populus==0.5.1
+eth-brownie==1.17.0

--- a/tests/datetime/conftest.py
+++ b/tests/datetime/conftest.py
@@ -1,0 +1,6 @@
+import pytest
+from brownie import accounts, DateTime
+
+@pytest.fixture(scope="session")
+def crontab():
+    return accounts[0].deploy(DateTime)

--- a/tests/datetime/test_day.py
+++ b/tests/datetime/test_day.py
@@ -59,6 +59,5 @@ import pytest
         (94694400, 1),  # Jan 1 1972
     ),
 )
-def test_get_day_from_timestamp(deployed_contracts, timestamp, day):
-    crontab = deployed_contracts.DateTime
+def test_get_day_from_timestamp(crontab, timestamp, day):
     assert crontab.getDay(timestamp) == day

--- a/tests/datetime/test_hour.py
+++ b/tests/datetime/test_hour.py
@@ -54,6 +54,5 @@ import pytest
         (63158400, 0),
     ),
 )
-def test_get_hour_from_timestamp(deployed_contracts, timestamp, hour):
-    crontab = deployed_contracts.DateTime
+def test_get_minute_from_timestamp(crontab, timestamp, hour):
     assert crontab.getHour(timestamp) == hour

--- a/tests/datetime/test_isLeapYear.py
+++ b/tests/datetime/test_isLeapYear.py
@@ -16,8 +16,7 @@ LEAP_YEARS = {
 @pytest.mark.parametrize(
     'year', range(1970, 2401),
 )
-def test_is_leap_year(deployed_contracts, year):
-    crontab = deployed_contracts.DateTime
+def test_is_leap_year(crontab, year):
     if year in LEAP_YEARS:
         assert crontab.isLeapYear(year) is True
     else:

--- a/tests/datetime/test_minute.py
+++ b/tests/datetime/test_minute.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 @pytest.mark.parametrize(
@@ -128,6 +127,5 @@ import pytest
         (63075600, 0),
     ),
 )
-def test_get_minute_from_timestamp(deployed_contracts, timestamp, minute):
-    crontab = deployed_contracts.DateTime
+def test_get_minute_from_timestamp(crontab, timestamp, minute):
     assert crontab.getMinute(timestamp) == minute

--- a/tests/datetime/test_month.py
+++ b/tests/datetime/test_month.py
@@ -61,7 +61,6 @@ import pytest
         (94694400, 1),
     ),
 )
-def test_get_month_from_timestamp(deployed_contracts, timestamp, month):
-    crontab = deployed_contracts.DateTime
+def test_get_month_from_timestamp(crontab, timestamp, month):
     assert crontab.getMonth(timestamp) == month
 

--- a/tests/datetime/test_second.py
+++ b/tests/datetime/test_second.py
@@ -67,6 +67,5 @@ import pytest
         (63072060, 0),
     ),
 )
-def test_get_second_from_timestamp(deployed_contracts, timestamp, second):
-    crontab = deployed_contracts.DateTime
+def test_get_second_from_timestamp(crontab, timestamp, second):
     assert crontab.getSecond(timestamp) == second

--- a/tests/datetime/test_to_timestamp.py
+++ b/tests/datetime/test_to_timestamp.py
@@ -13,6 +13,5 @@ import datetime
         (datetime.datetime(2016, 3, 1), 1456790400),
     ),
 )
-def test_dt_to_timestamp(deployed_contracts, dt, timestamp):
-    crontab = deployed_contracts.DateTime
+def test_dt_to_timestamp(crontab, dt, timestamp):
     assert crontab.toTimestamp(dt.year, dt.month, dt.day, dt.hour, dt.minute, dt.second) == timestamp

--- a/tests/datetime/test_weekday.py
+++ b/tests/datetime/test_weekday.py
@@ -21,7 +21,6 @@ import pytest
         (68342400, 4),
     ),
 )
-def test_get_weekday_from_timestamp(deployed_contracts, timestamp, weekday):
-    crontab = deployed_contracts.DateTime
+def test_get_weekday_from_timestamp(crontab, timestamp, weekday):
     assert crontab.getWeekday(timestamp) == weekday
 

--- a/tests/datetime/test_year.py
+++ b/tests/datetime/test_year.py
@@ -866,6 +866,5 @@ import pytest
 (13537929599, 2398),
 )
 )
-def test_get_year_from_timestamp(deployed_contracts, timestamp, year):
-    crontab = deployed_contracts.DateTime
+def test_get_year_from_timestamp(crontab, timestamp, year):
     assert crontab.getYear(timestamp) == year


### PR DESCRIPTION
This PR does the following:
* upgrades the DateTime contract to sol v0.8
* introduces [brownie](https://github.com/eth-brownie/brownie) as a dependency for running tests locally
* adds a CI workflow to hopefully make future changes easier to manage